### PR TITLE
Implement unzipping and directory creation in file upload

### DIFF
--- a/curator/src/main/java/org/apache/oodt/cas/curation/rest/UploadBackend.java
+++ b/curator/src/main/java/org/apache/oodt/cas/curation/rest/UploadBackend.java
@@ -21,7 +21,14 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
@@ -29,6 +36,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.MultipartBody;
@@ -42,34 +50,81 @@ import org.apache.oodt.cas.curation.configuration.Configuration;
  */
 @Path("upload")
 public class UploadBackend {
-    /**
-     * Construct using configuration to determine upload area
-     */
-    public UploadBackend() {}
+  /**
+   * Construct using configuration to determine upload area
+   */
+  public UploadBackend() {}
 
-    @POST
-    @Path("file")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    /**
-     * Handles the uploading of the data, by copying all data out of the input stream.
-     * @param mbody - body of the multipart post
-     * @return - OK response on success
-     * @throws IOException - exception thrown on error
-     */
-    public Response upload(MultipartBody mbody) throws IOException {
-    	List<Attachment> attachments = mbody.getAllAttachments();
-        for (Attachment attachment : attachments) {
-            String filename = attachment.getContentDisposition().getParameter("filename");    
-            try {
-                InputStream in = attachment.getDataHandler().getInputStream();
-                OutputStream os = new FileOutputStream(new File(Configuration.getWithReplacement(Configuration.UPLOAD_AREA_CONFIG),filename));
-                IOUtils.copy(in,os);
-                in.close();
-                os.close();
-            } catch(IOException e) {
-                throw new IOException("Failed uploading file:",e);
-            }
+  @POST
+  @Path("file")
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  /**
+   * Handles the uploading of the data, by copying all data out of the input stream.
+   * @param mbody - body of the multipart post
+   * @return - OK response on success
+   * @throws IOException - exception thrown on error
+   */
+  public Response upload(MultipartBody mbody) throws IOException {
+    List<Attachment> attachments = mbody.getAllAttachments();
+    for (Attachment attachment : attachments) {
+      String filename = attachment.getContentDisposition().getParameter("filename");
+      if (filename.endsWith(".zip")) {
+        Map<String, InputStream> unzipdMap = unzipAttachment(filename, attachment.getDataHandler().getInputStream());
+        Iterator<Entry<String, InputStream>> it = unzipdMap.entrySet().iterator();
+        while (it.hasNext()) {
+          Map.Entry<String, InputStream> pair = (Map.Entry<String, InputStream>) it.next();
+          writeToStaging(pair.getKey(), pair.getValue());
         }
-        return Response.ok().build();
+      } else {
+        writeToStaging(filename, attachment.getDataHandler().getInputStream());
+      }
     }
+    return Response.ok().build();
+  }
+
+  private Map<String, InputStream> unzipAttachment(String filename, InputStream is) throws IOException {
+    writeToStaging(filename, is); // first write the zipFile to staging
+    String tmpZip = "/tmp/" + filename; // write file to /tmp for copy
+    ZipFile zipFile = null;
+    HashMap<String, InputStream> fileMap = new HashMap<String, InputStream>();
+    try {
+      FileUtils.copyInputStreamToFile(is, new File(tmpZip));
+      zipFile = new ZipFile(tmpZip);
+
+      final Enumeration<? extends ZipEntry> entries = zipFile.entries();
+
+      while(entries.hasMoreElements()) {
+        ZipEntry entry = (ZipEntry)entries.nextElement();
+
+        if(entry.isDirectory()) {
+          // Assume directories are stored parents first then children.
+          System.out.println("Extracting directory: " + entry.getName());
+          // This is not robust, just for demonstration purposes.
+          (new File(Configuration.getWithReplacement(Configuration.UPLOAD_AREA_CONFIG),entry.getName())).mkdir();
+          continue;
+        }
+
+        System.out.println("Extracting file: " + entry.getName());
+        fileMap.put(entry.getName(), zipFile.getInputStream(entry));
+      }
+
+      zipFile.close();
+    } catch (IOException ioe) {
+      System.err.println("Unhandled exception:");
+      ioe.printStackTrace();
+    }
+    return fileMap;
+  }
+
+  private void writeToStaging(String filename, InputStream in) throws IOException {
+    try {
+      OutputStream os = new FileOutputStream(new File(Configuration.getWithReplacement(Configuration.UPLOAD_AREA_CONFIG),filename));
+      IOUtils.copy(in,os);
+      in.close();
+      os.close();
+    } catch(IOException e) {
+      throw new IOException("Failed uploading file:",e);
+    }
+
+  }
 }

--- a/curator/src/main/webapp/WEB-INF/web.xml
+++ b/curator/src/main/webapp/WEB-INF/web.xml
@@ -25,8 +25,8 @@ the License.
 	 <init-param>
 	  <param-name>jaxrs.serviceClasses</param-name>
 	  <param-value>
-        org.apache.oodt.cas.curation.rest.UploadBackend
-        org.apache.oodt.cas.curation.rest.MetadataBackend
+            org.apache.oodt.cas.curation.rest.UploadBackend
+            org.apache.oodt.cas.curation.rest.MetadataBackend
 	    org.apache.oodt.cas.curation.rest.DirectoryBackend
 	    org.apache.oodt.cas.curation.rest.IngestBackend
 	  </param-value>

--- a/curator/src/main/webapp/index.html
+++ b/curator/src/main/webapp/index.html
@@ -1,27 +1,29 @@
 <!doctype html>
 <html>
-	<head>
-	    <meta charset="utf-8">
+    <head>
+        <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-		<title>New Curator</title>
-		<script src="lib/require.js" data-main="js-new/main.js"></script>
-		<link href="css/bootstrap.min.css" rel="stylesheet">
-		<link rel="stylesheet" type="text/css" href="css/style.css">
+        <title>New Curator</title>
+        <script src="lib/require.js" data-main="js-new/main.js"></script>
+        <link href="css/bootstrap.min.css" rel="stylesheet">
+        <link rel="stylesheet" type="text/css" href="css/style.css">
         <link rel="stylesheet" type="text/css" href="lib/themes/default/style.min.css" />
         <link rel="stylesheet" type="text/css" href="lib/css/jquery.dataTables_themeroller.css" />
         <link rel="stylesheet" type="text/css" href="lib/css/jquery.dataTables.css" />
         <link rel="stylesheet" type="text/css" href="lib/css/dropzone.css" />
         
-	</head>
-	<body>
+    </head>
+    <body>
         <div id="wrapper" class="content container-fluid">
             <div class="row intro">
                 <div class="col-md-offset-1 col-md-10">
                     <h1>OODT CAS Curator</h1>
                     <hr/>
                     <p>
-                    The OODT CAS-Curator allows the user to ingest files from the given staging area. The user may also upload files into the staging area, and edit the metadata pertaining to these files before the ingestion takes place.
+                    The OODT CAS-Curator allows the user to ingest files from the given staging area. The user may also 
+                    upload files into the staging area, and edit the metadata pertaining to these files before the 
+                    ingestion takes place.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
This PR adds ability to upload .zip archives to the curator dropzone. When the input stream is received on the server side code and a .zip extension is detected within the filename the InputStream is wrapped in a ZipFileInputStream and processed accordingly.
The actual .zip file is also ingested alongside all internal files. 
